### PR TITLE
Adjust values for Kerbalism default profile

### DIFF
--- a/GameData/WildBlueIndustries/000WildBlueTools/ModuleManagerPatches/MM_Kerbalism.cfg
+++ b/GameData/WildBlueIndustries/000WildBlueTools/ModuleManagerPatches/MM_Kerbalism.cfg
@@ -10,8 +10,8 @@ STORAGE_TEMPLATE:NEEDS[Kerbalism]
 	RESOURCE
 	{
 		name = Food
-		amount = 5600
-		maxAmount = 5600
+		amount = 18000
+		maxAmount = 18000
 	}
 
 }
@@ -28,8 +28,8 @@ STORAGE_TEMPLATE:NEEDS[Kerbalism]
 	RESOURCE
 	{
 		name = Oxygen
-		amount = 5600
-		maxAmount = 5600
+		amount = 280000
+		maxAmount = 280000
 	}
 
 }


### PR DESCRIPTION
This proposed change adjusts the default values for food to match the early-game equivalency of food to LF - namely the small food container in Kerbalism can hold 200 food, and an equally sized fuel container can hold 20 LF.  18000 is therefore the 'correct' amount of food and will make WildBlue stuff hold a useful amount of food for the default profile.

Regarding Oxygen, I haven't been able to find a good common ground for an exact measurement, but it certainly shouldn't be exactly the same as food - command pods are at a 100 food (9 kerbal-days) to 5000 oxygen (12 kerbal-days) storage, so I just multiplied the O2 storage by 50 and hope it's closer to correct, with some fudge factor for O2 being harder to store in generic containers maybe?
