### PR TITLE
Fix malformed HTML

### DIFF
--- a/Omni/WBIOmniConverter.cs
+++ b/Omni/WBIOmniConverter.cs
@@ -324,7 +324,7 @@ namespace WildBlueIndustries
             else if (requiresSplashed)
                 info.AppendLine("<color=white><b>Must be splashed:</b> YES</color>");
             else
-                info.AppendLine("<b>Must be splashed:</b> NO</color>");
+                info.AppendLine("<color=white><b>Must be splashed:</b> NO</color>");
 
             //Required anomalies
             if (!string.IsNullOrEmpty(requiredAnomalies))


### PR DESCRIPTION
Fixes #42

This is because the color tag is not paired. So the game rejects the invalid HTML and treat it as text.

Tests: Rebuilt DLL and tried it in game. Works for me.